### PR TITLE
tf.loadModel is not a function

### DIFF
--- a/sketcher/main.js
+++ b/sketcher/main.js
@@ -199,7 +199,7 @@ preprocess the data
 function preprocess(imgData) {
     return tf.tidy(() => {
         //convert to a tensor 
-        let tensor = tf.fromPixels(imgData, numChannels = 1)
+        let tensor = tf.browser.fromPixels(imgData, numChannels = 1)
         
         //resize 
         const resized = tf.image.resizeBilinear(tensor, [28, 28]).toFloat()
@@ -222,7 +222,7 @@ async function start(cur_mode) {
     mode = cur_mode
     
     //load the model 
-    model = await tf.loadModel('model2/model.json')
+    model = await tf.loadLayersModel('model2/model.json')
     
     //warm up 
     model.predict(tf.zeros([1, 28, 28, 1]))


### PR DESCRIPTION
TensorFlow.js 1.0 has API changes:
- tf.loadModel is now tf.loadLayersModel
- tf.fromPixels is now tf.browser.fromPixels